### PR TITLE
Add support for new API paths on UDM.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,4 +6,5 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/stretchr/testify v1.4.0
+	golang.org/x/net v0.0.0-20200202094626-16171245cfb2
 )

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,11 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/net v0.0.0-20200202094626-16171245cfb2 h1:CCH4IOTTfewWjGOlSp+zGcjutRKlBEZQ6wTn8ozI/nI=
+golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/types.go
+++ b/types.go
@@ -23,15 +23,31 @@ const (
 	APIClientPath string = "/api/s/%s/stat/sta"
 	// APIDevicePath is where we get data about Unifi devices.
 	APIDevicePath string = "/api/s/%s/stat/device"
-	// APINetworkPath contains network-configuration data. Not really graphable.
-	APINetworkPath string = "/api/s/%s/rest/networkconf"
-	// APIUserGroupPath contains usergroup configurations.
-	APIUserGroupPath string = "/api/s/%s/rest/usergroup"
 	// APILoginPath is Unifi Controller Login API Path
 	APILoginPath string = "/api/login"
+	// APILoginPathNew is how we log into UDM 5.12.55+
+	APILoginPathNew string = "/api/auth/login"
 	// APIIPSEvents returns Intrusion Detection Systems Events
 	APIIPSEvents string = "/api/s/%s/stat/ips/event"
+	// APIPrefixNew is the prefix added to the new API paths; except login. duh.
+	APIPrefixNew string = "/proxy/network"
 )
+
+// path returns the correct api path based on the new variable.
+// new is based on the unifi-controller output. is it new or old output?
+func (u *Unifi) path(path string) string {
+	if u.isNew {
+		if path == APILoginPath {
+			return APILoginPathNew
+		}
+
+		if !strings.HasPrefix(path, APIPrefixNew) && path != APILoginPathNew {
+			return APIPrefixNew + path
+		}
+	}
+
+	return path
+}
 
 // Logger is a base type to deal with changing log outputs. Create a logger
 // that matches this interface to capture debug and error logs.
@@ -70,6 +86,7 @@ type Unifi struct {
 	*http.Client
 	*Config
 	*server
+	isNew bool
 }
 
 // server is the /status endpoint from the Unifi controller.


### PR DESCRIPTION
This contribution adds support for the new API paths that have shown up on the UniFi Dream Machine. All the paths, with the exception of login, have a new prefix. Login has a new path. To determine which path to use, we perform a request to `/` when the controller is configured. If that request returns a 200 OK then we assume it's a new controller. The previous controller versions return a 302 redirect to `/manage`. From that point forward the API paths requested are prefixed with the new prefix if it's a new controller.