### PR TITLE
Trim whitespace off client and device names.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 language: go
 go:
-- 1.13.x
+- 1.14.x
 before_install:
   # download super-linter: golangci-lint
 - curl -sL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin latest
-install:
-- go mod download
 script:
-- golangci-lint run --enable-all -e G402 -D gochecknoglobals
+- golangci-lint run --enable-all
 - go test ./...

--- a/clients.go
+++ b/clients.go
@@ -2,6 +2,7 @@ package unifi
 
 import (
 	"fmt"
+	"strings"
 )
 
 // GetClients returns a response full of clients' data from the UniFi Controller.
@@ -26,8 +27,8 @@ func (u *Unifi) GetClients(sites Sites) (Clients, error) {
 			// Add the special "Site Name" to each client. This becomes a Grafana filter somewhere.
 			response.Data[i].SiteName = site.Desc + " (" + site.Name + ")"
 			// Fix name and hostname fields. Sometimes one or the other is blank.
-			response.Data[i].Hostname = pick(d.Hostname, d.Name, d.Mac)
-			response.Data[i].Name = pick(d.Name, d.Hostname)
+			response.Data[i].Hostname = strings.TrimSpace(pick(d.Hostname, d.Name, d.Mac))
+			response.Data[i].Name = strings.TrimSpace(pick(d.Name, d.Hostname))
 		}
 
 		data = append(data, response.Data...)

--- a/devices.go
+++ b/devices.go
@@ -3,6 +3,7 @@ package unifi
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 )
 
 // GetDevices returns a response full of devices' data from the UniFi Controller.
@@ -50,25 +51,25 @@ func (u *Unifi) parseDevices(data []json.RawMessage, siteName string) *Devices {
 		case "uap":
 			dev := &UAP{SiteName: siteName, SourceName: u.URL}
 			if u.unmarshalDevice(assetType, r, dev) == nil {
-				dev.Name = pick(dev.Name, dev.Mac)
+				dev.Name = strings.TrimSpace(pick(dev.Name, dev.Mac))
 				devices.UAPs = append(devices.UAPs, dev)
 			}
 		case "ugw", "usg": // in case they ever fix the name in the api.
 			dev := &USG{SiteName: siteName, SourceName: u.URL}
 			if u.unmarshalDevice(assetType, r, dev) == nil {
-				dev.Name = pick(dev.Name, dev.Mac)
+				dev.Name = strings.TrimSpace(pick(dev.Name, dev.Mac))
 				devices.USGs = append(devices.USGs, dev)
 			}
 		case "usw":
 			dev := &USW{SiteName: siteName, SourceName: u.URL}
 			if u.unmarshalDevice(assetType, r, dev) == nil {
-				dev.Name = pick(dev.Name, dev.Mac)
+				dev.Name = strings.TrimSpace(pick(dev.Name, dev.Mac))
 				devices.USWs = append(devices.USWs, dev)
 			}
 		case "udm":
 			dev := &UDM{SiteName: siteName, SourceName: u.URL}
 			if u.unmarshalDevice(assetType, r, dev) == nil {
-				dev.Name = pick(dev.Name, dev.Mac)
+				dev.Name = strings.TrimSpace(pick(dev.Name, dev.Mac))
 				devices.UDMs = append(devices.UDMs, dev)
 			}
 		default:

--- a/dpi.go
+++ b/dpi.go
@@ -56,7 +56,7 @@ func (d DPIMap) Keys() []string {
 
 // DPICats maps the categories to descriptions.
 // From: https://fw-download.ubnt.com/data/usg-dpi/1628-debian-v1.442.0-05f5a57eaef344358bd5a8e84a184c18.tar
-var DPICats = DPIMap{
+var DPICats = DPIMap{ // nolint: gochecknoglobals
 	0:   "Instant Messengers",
 	1:   "Peer-to-Peer Networks",
 	3:   "File Sharing",
@@ -83,7 +83,7 @@ var DPICats = DPIMap{
 
 // DPIApps maps the applications to names.
 // From: https://fw-download.ubnt.com/data/usg-dpi/1628-debian-v1.442.0-05f5a57eaef344358bd5a8e84a184c18.tar
-var DPIApps = DPIMap{
+var DPIApps = DPIMap{ // nolint: gochecknoglobals
 	1:        "MSN",
 	2:        "Yahoo Messenger",
 	3:        "AIM/ICQ/iIM",

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,11 @@
 module github.com/unifi-poller/unifi
 
-go 1.13
+go 1.14
 
 require (
 	github.com/davecgh/go-spew v1.1.1
+	github.com/pkg/errors v0.9.1
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/stretchr/testify v1.4.0
-	golang.org/x/net v0.0.0-20200202094626-16171245cfb2
+	golang.org/x/net v0.0.0-20200602114024-627f9648deb9
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -9,7 +11,10 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2 h1:CCH4IOTTfewWjGOlSp+zGcjutRKlBEZQ6wTn8ozI/nI=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200602114024-627f9648deb9 h1:pNX+40auqi2JqRfOP1akLGtYcn15TUbkhwuCO3foqqM=
+golang.org/x/net v0.0.0-20200602114024-627f9648deb9/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=

--- a/ids.go
+++ b/ids.go
@@ -6,6 +6,8 @@ import (
 	"io/ioutil"
 	"net/http"
 	"time"
+
+	"github.com/pkg/errors"
 )
 
 // IDSList contains a list that contains all of the IDS Events on a controller.
@@ -135,7 +137,7 @@ func (u *Unifi) GetSiteIDS(site *Site, from, to time.Time) ([]*IDS, error) {
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("invalid status code from server %s", resp.Status)
+		return nil, errors.Wrap(errInvalidStatusCode, resp.Status)
 	}
 
 	if err := json.Unmarshal(body, &response); err != nil {

--- a/site.go
+++ b/site.go
@@ -5,8 +5,9 @@ import (
 	"strings"
 )
 
-// Satisfy gomnd
-const oneItem = 1
+var (
+	errDPIDataBug = fmt.Errorf("dpi data table contains more than 1 item; please open a bug report")
+)
 
 // GetSites returns a list of configured sites on the UniFi controller.
 func (u *Unifi) GetSites() (Sites, error) {
@@ -24,7 +25,7 @@ func (u *Unifi) GetSites() (Sites, error) {
 		// Add special SourceName value.
 		response.Data[i].SourceName = u.URL
 		// If the human name is missing (description), set it to the cryptic name.
-		response.Data[i].Desc = pick(d.Desc, d.Name)
+		response.Data[i].Desc = strings.TrimSpace(pick(d.Desc, d.Name))
 		// Add the custom site name to each site. used as a Grafana filter somewhere.
 		response.Data[i].SiteName = d.Desc + " (" + d.Name + ")"
 		sites = append(sites, d.Name) // used for debug log only
@@ -51,9 +52,9 @@ func (u *Unifi) GetSiteDPI(sites Sites) ([]*DPITable, error) {
 			return nil, err
 		}
 
-		if l := len(response.Data); l > oneItem {
-			return nil, fmt.Errorf("dpi data table contains more than 1 item; please open a bug report")
-		} else if l != oneItem {
+		if l := len(response.Data); l > 1 {
+			return nil, errDPIDataBug
+		} else if l != 1 {
 			continue
 		}
 

--- a/types.go
+++ b/types.go
@@ -6,6 +6,12 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+
+	"github.com/pkg/errors"
+)
+
+var (
+	errCannotUnmarshalFlexInt = fmt.Errorf("cannot unmarshal to FlexInt")
 )
 
 // This is a list of unifi API paths.
@@ -124,7 +130,7 @@ func (f *FlexInt) UnmarshalJSON(b []byte) error {
 		f.Txt = "0"
 		f.Val = 0
 	default:
-		return fmt.Errorf("cannot unmarshal to FlexInt: %s", b)
+		return errors.Wrapf(errCannotUnmarshalFlexInt, "%v", b)
 	}
 
 	return nil

--- a/types_test.go
+++ b/types_test.go
@@ -1,4 +1,4 @@
-package unifi
+package unifi // nolint: testpackage
 
 import (
 	"encoding/json"

--- a/uap.go
+++ b/uap.go
@@ -399,7 +399,7 @@ type RadioTable []struct {
 	WlangroupID        string   `json:"wlangroup_id"`
 }
 
-// RadioTableStats is part of the data shared between UAP and UDM
+// RadioTableStats is part of the data shared between UAP and UDM.
 type RadioTableStats []struct {
 	Name         string      `json:"name"`
 	Channel      FlexInt     `json:"channel"`

--- a/uap_test.go
+++ b/uap_test.go
@@ -1,4 +1,4 @@
-package unifi
+package unifi // nolint: testpackage
 
 import (
 	"testing"

--- a/udm.go
+++ b/udm.go
@@ -69,8 +69,12 @@ type UDM struct {
 		MaxMirrorSessions    FlexInt `json:"max_mirror_sessions"`
 		MaxAggregateSessions FlexInt `json:"max_aggregate_sessions"`
 	} `json:"switch_caps"`
-	HasFan            FlexBool    `json:"has_fan"`
-	HasTemperature    FlexBool    `json:"has_temperature"`
+	HasFan       FlexBool `json:"has_fan"`
+	Temperatures []struct {
+		Name  string  `json:"name"`
+		Type  string  `json:"type"`
+		Value float64 `json:"value"`
+	} `json:"temperatures"`
 	RulesetInterfaces interface{} `json:"ruleset_interfaces"`
 	/* struct {
 		Br0  string `json:"br0"`

--- a/udm.go
+++ b/udm.go
@@ -70,7 +70,7 @@ type UDM struct {
 		MaxAggregateSessions FlexInt `json:"max_aggregate_sessions"`
 	} `json:"switch_caps"`
 	HasFan            FlexBool      `json:"has_fan"`
-	Temperatures      *Temperatures `json:"temperatures,omitempty"`
+	Temperatures      []Temperature `json:"temperatures,omitempty"`
 	RulesetInterfaces interface{}   `json:"ruleset_interfaces"`
 	/* struct {
 		Br0  string `json:"br0"`
@@ -174,7 +174,7 @@ type NetworkTable []struct {
 	TxPackets              FlexInt  `json:"tx_packets"`
 }
 
-type Temperatures []struct {
+type Temperature struct {
 	Name  string  `json:"name"`
 	Type  string  `json:"type"`
 	Value float64 `json:"value"`

--- a/udm.go
+++ b/udm.go
@@ -175,7 +175,7 @@ type NetworkTable []struct {
 }
 
 // UDMStat holds the "stat" data for a dream machine.
-// A dream machine is a USG + USW + Controller
+// A dream machine is a USG + USW + Controller.
 type UDMStat struct {
 	*Gw `json:"gw"`
 	*Sw `json:"sw"`

--- a/udm.go
+++ b/udm.go
@@ -69,9 +69,9 @@ type UDM struct {
 		MaxMirrorSessions    FlexInt `json:"max_mirror_sessions"`
 		MaxAggregateSessions FlexInt `json:"max_aggregate_sessions"`
 	} `json:"switch_caps"`
-	HasFan            FlexBool     `json:"has_fan"`
-	Temperatures      Temperatures `json:"temperatures"`
-	RulesetInterfaces interface{}  `json:"ruleset_interfaces"`
+	HasFan            FlexBool      `json:"has_fan"`
+	Temperatures      *Temperatures `json:"temperatures,omitempty"`
+	RulesetInterfaces interface{}   `json:"ruleset_interfaces"`
 	/* struct {
 		Br0  string `json:"br0"`
 		Eth0 string `json:"eth0"`
@@ -131,12 +131,6 @@ type UDM struct {
 	NumHandheld     FlexInt `json:"num_handheld"`       // USG
 }
 
-type Temperatures []struct {
-	Name  string  `json:"name"`
-	Type  string  `json:"type"`
-	Value float64 `json:"value"`
-}
-
 // NetworkTable is the list of networks on a gateway.
 type NetworkTable []struct {
 	ID                     string   `json:"_id"`
@@ -178,6 +172,12 @@ type NetworkTable []struct {
 	RxPackets              FlexInt  `json:"rx_packets"`
 	TxBytes                FlexInt  `json:"tx_bytes"`
 	TxPackets              FlexInt  `json:"tx_packets"`
+}
+
+type Temperatures []struct {
+	Name  string  `json:"name"`
+	Type  string  `json:"type"`
+	Value float64 `json:"value"`
 }
 
 // UDMStat holds the "stat" data for a dream machine.

--- a/udm.go
+++ b/udm.go
@@ -69,13 +69,9 @@ type UDM struct {
 		MaxMirrorSessions    FlexInt `json:"max_mirror_sessions"`
 		MaxAggregateSessions FlexInt `json:"max_aggregate_sessions"`
 	} `json:"switch_caps"`
-	HasFan       FlexBool `json:"has_fan"`
-	Temperatures []struct {
-		Name  string  `json:"name"`
-		Type  string  `json:"type"`
-		Value float64 `json:"value"`
-	} `json:"temperatures"`
-	RulesetInterfaces interface{} `json:"ruleset_interfaces"`
+	HasFan            FlexBool     `json:"has_fan"`
+	Temperatures      Temperatures `json:"temperatures"`
+	RulesetInterfaces interface{}  `json:"ruleset_interfaces"`
 	/* struct {
 		Br0  string `json:"br0"`
 		Eth0 string `json:"eth0"`
@@ -133,6 +129,12 @@ type UDM struct {
 	NumDesktop      FlexInt `json:"num_desktop"`        // USG
 	NumMobile       FlexInt `json:"num_mobile"`         // USG
 	NumHandheld     FlexInt `json:"num_handheld"`       // USG
+}
+
+type Temperatures []struct {
+	Name  string  `json:"name"`
+	Type  string  `json:"type"`
+	Value float64 `json:"value"`
 }
 
 // NetworkTable is the list of networks on a gateway.

--- a/unifi_test.go
+++ b/unifi_test.go
@@ -1,4 +1,4 @@
-package unifi
+package unifi // nolint: testpackage
 
 import (
 	"io/ioutil"

--- a/usg_test.go
+++ b/usg_test.go
@@ -1,4 +1,4 @@
-package unifi
+package unifi // nolint: testpackage
 
 import (
 	"testing"

--- a/usw_test.go
+++ b/usw_test.go
@@ -1,4 +1,4 @@
-package unifi
+package unifi // nolint: testpackage
 
 import (
 	"testing"


### PR DESCRIPTION
This contribution updates dependency libraries and trims whitespace off client and device names. Also adds UDM temperature struct. Closes https://github.com/unifi-poller/unifi-poller/issues/226.