### PR TITLE
add networks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /vendor
+*.swp

--- a/networks.go
+++ b/networks.go
@@ -1,0 +1,74 @@
+package unifi
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// GetNetworks returns a response full of network data from the UniFi Controller.
+func (u *Unifi) GetNetworks(sites []*Site) ([]Network, error) {
+	networks := make([]Network, 0)
+
+	for _, site := range sites {
+		var response struct {
+			Data []json.RawMessage `json:"data"`
+		}
+
+		networkPath := fmt.Sprintf(APINetworkPath, site.Name)
+		if err := u.GetData(networkPath, &response); err != nil {
+			return nil, err
+		}
+
+		for _, data := range response.Data {
+			network := u.parseNetwork(data, site.SiteName)
+			networks = append(networks, *network)
+		}
+	}
+
+	return networks, nil
+}
+
+// parseNetwork parses the raw JSON from the Unifi Controller into network structures.
+func (u *Unifi) parseNetwork(data json.RawMessage, siteName string) *Network {
+	network := new(Network)
+	u.unmarshalNetwork(data, &network)
+	return network
+}
+
+// unmarshalNetwork handles logging for the unmarshal operations in parseNetwork().
+func (u *Unifi) unmarshalNetwork(data json.RawMessage, v interface{}) (err error) {
+	if err = json.Unmarshal(data, v); err != nil {
+		u.ErrorLog("json.Unmarshal(): %v", err)
+		u.ErrorLog("Enable Debug Logging to output the failed payload.")
+
+		json, err := data.MarshalJSON()
+		u.DebugLog("Failed Payload: %s (marshal err: %v)", json, err)
+		u.DebugLog("The above payload can prove useful during torubleshooting when you open an Issue:")
+		u.DebugLog("==- https://github.com/unifi-poller/unifi/issues/new -==")
+	}
+
+	return err
+}
+
+// Network is metadata about a network managed by a UniFi controller
+type Network struct {
+	DhcpdDNSEnabled        FlexBool `json:"dhcpd_dns_enabled"`
+	DhcpdEnabled           FlexBool `json:"dhcpd_enabled"`
+	DhcpdGatewayEnabled    FlexBool `json:"dhcpd_gateway_enabled"`
+	DhcpdIP1               string   `json:"dhcpd_ip_1"`
+	DhcpdLeasetime         FlexInt  `json:"dhcpd_leasetime"`
+	DhcpRelayEnabled       FlexBool `json:"dhcp_relay_enabled"`
+	DhcpdTimeOffsetEnabled FlexBool `json:"dhcpd_time_offset_enabled"`
+	DhcpGuardEnabled       FlexBool `json:"dhcpguard_enabled"`
+	DomainName             string   `json:"domain_name"`
+	Enabled                FlexBool `json:"enabled"`
+	ID                     string   `json:"_id"`
+	IPSubnet               string   `json:"ip_subnet"`
+	IsNat                  FlexBool `json:"is_nat"`
+	Name                   string   `json:"name"`
+	Networkgroup           string   `json:"networkgroup"`
+	Purpose                string   `json:"purpose"`
+	SiteID                 string   `json:"site_id"`
+	Vlan                   FlexInt  `json:"vlan"`
+	VlanEnabled            FlexBool `json:"vlan_enabled"`
+}

--- a/networks.go
+++ b/networks.go
@@ -35,21 +35,6 @@ func (u *Unifi) parseNetwork(data json.RawMessage, siteName string) *Network {
 	return network
 }
 
-// unmarshalNetwork handles logging for the unmarshal operations in parseNetwork().
-func (u *Unifi) unmarshalNetwork(data json.RawMessage, v interface{}) (err error) {
-	if err = json.Unmarshal(data, v); err != nil {
-		u.ErrorLog("json.Unmarshal(): %v", err)
-		u.ErrorLog("Enable Debug Logging to output the failed payload.")
-
-		json, err := data.MarshalJSON()
-		u.DebugLog("Failed Payload: %s (marshal err: %v)", json, err)
-		u.DebugLog("The above payload can prove useful during torubleshooting when you open an Issue:")
-		u.DebugLog("==- https://github.com/unifi-poller/unifi/issues/new -==")
-	}
-
-	return err
-}
-
 // Network is metadata about a network managed by a UniFi controller
 type Network struct {
 	DhcpdDNSEnabled        FlexBool `json:"dhcpd_dns_enabled"`

--- a/networks.go
+++ b/networks.go
@@ -29,10 +29,9 @@ func (u *Unifi) GetNetworks(sites []*Site) ([]Network, error) {
 }
 
 // parseNetwork parses the raw JSON from the Unifi Controller into network structures.
-func (u *Unifi) parseNetwork(data json.RawMessage, siteName string) *Network {
+func (u *Unifi) parseNetwork(data json.RawMessage, siteName string) (*Network, error) {
 	network := new(Network)
-	u.unmarshalNetwork(data, &network)
-	return network
+	return network, u.unmarshalDevice(data, network)
 }
 
 // Network is metadata about a network managed by a UniFi controller

--- a/networks.go
+++ b/networks.go
@@ -20,7 +20,11 @@ func (u *Unifi) GetNetworks(sites []*Site) ([]Network, error) {
 		}
 
 		for _, data := range response.Data {
-			network := u.parseNetwork(data, site.SiteName)
+			network, err := u.parseNetwork(data, site.SiteName)
+			if err != nil {
+				return networks, err
+			}
+
 			networks = append(networks, *network)
 		}
 	}

--- a/types.go
+++ b/types.go
@@ -29,6 +29,8 @@ const (
 	APIClientDPI string = "/api/s/%s/stat/stadpi"
 	// APIClientPath is Unifi Clients API Path
 	APIClientPath string = "/api/s/%s/stat/sta"
+	// APINetworkPath is where we get data about Unifi networks.
+	APINetworkPath string = "/api/s/%s/rest/networkconf"
 	// APIDevicePath is where we get data about Unifi devices.
 	APIDevicePath string = "/api/s/%s/stat/device"
 	// APILoginPath is Unifi Controller Login API Path


### PR DESCRIPTION
I wanted to use this to pull the basic info about networks from my controller, and got the API path by snooping on network requests in my browser when loading the “Networks” pane of the settings screen.
```
ADR-ego:~/dev/sources/unifi/examples$ go run main.go 
2020/09/08 00:20:33 Requesting https://10.10.0.5:8443/ to determine API paths
2020/09/08 00:20:33 Requesting https://10.10.0.5:8443/api/login, with params: true, cookies: 0
2020/09/08 00:20:34 Requested https://10.10.0.5:8443/api/login: elapsed 857ms, returned 41 bytes
2020/09/08 00:20:34 Requesting https://10.10.0.5:8443/status, with params: false, cookies: 2
2020/09/08 00:20:34 Requested https://10.10.0.5:8443/status: elapsed 5ms, returned 135 bytes
2020/09/08 00:20:34 Requesting https://10.10.0.5:8443/api/stat/sites, with params: false, cookies: 2
2020/09/08 00:20:34 Requested https://10.10.0.5:8443/api/stat/sites: elapsed 41ms, returned 864 bytes
2020/09/08 00:20:34 Found 1 site(s): default
2020/09/08 00:20:34 1 Unifi Sites Found:  [0xc00011c8f0]
2020/09/08 00:20:34 Requesting https://10.10.0.5:8443/api/s/default/rest/networkconf, with params: false, cookies: 2
2020/09/08 00:20:34 Requested https://10.10.0.5:8443/api/s/default/rest/networkconf: elapsed 88ms, returned 1796 bytes
2020/09/08 00:20:34 Unifi networks: []unifi.Network{unifi.Network{DhcpdDNSEnabled:unifi.FlexBool{Val:false, Txt:"false"}, DhcpdEnabled:unifi.FlexBool{Val:false, Txt:"false"}, DhcpdGatewayEnabled:unifi.FlexBool{Val:false, Txt:"false"}, DhcpdIP1:"10.10.0.1", DhcpdLeasetime:unifi.FlexInt{Val:86400, Txt:"86400"}, DhcpRelayEnabled:unifi.FlexBool{Val:false, Txt:"false"}, DhcpdTimeOffsetEnabled:unifi.FlexBool{Val:false, Txt:"false"}, DhcpGuardEnabled:unifi.FlexBool{Val:false, Txt:"false"}, DomainName:"", Enabled:unifi.FlexBool{Val:true, Txt:"true"}, ID:"56c5403503c8ded5141d12c7", IPSubnet:"192.168.1.1/24", IsNat:unifi.FlexBool{Val:true, Txt:"true"}, Name:"LAN", Networkgroup:"LAN", Purpose:"corporate", SiteID:"56c5403303c8ded5141d12c2", Vlan:unifi.FlexInt{Val:0, Txt:""}, VlanEnabled:unifi.FlexBool{Val:false, Txt:"false"}}, unifi.Network{DhcpdDNSEnabled:unifi.FlexBool{Val:false, Txt:"false"}, DhcpdEnabled:unifi.FlexBool{Val:false, Txt:"false"}, DhcpdGatewayEnabled:unifi.FlexBool{Val:false, Txt:"false"}, DhcpdIP1:"10.10.0.1", DhcpdLeasetime:unifi.FlexInt{Val:86400, Txt:"86400"}, DhcpRelayEnabled:unifi.FlexBool{Val:false, Txt:"false"}, DhcpdTimeOffsetEnabled:unifi.FlexBool{Val:false, Txt:"false"}, DhcpGuardEnabled:unifi.FlexBool{Val:true, Txt:"true"}, DomainName:"adr.local", Enabled:unifi.FlexBool{Val:true, Txt:"true"}, ID:"5a4e987c34de20142beaad58", IPSubnet:"10.10.0.1/23", IsNat:unifi.FlexBool{Val:true, Txt:"true"}, Name:"Trusted", Networkgroup:"LAN", Purpose:"corporate", SiteID:"56c5403303c8ded5141d12c2", Vlan:unifi.FlexInt{Val:2, Txt:"2"}, VlanEnabled:unifi.FlexBool{Val:true, Txt:"true"}}}
```