### PR TITLE
Add all Device Manager methods, original: Add ability to power cycle USW port

### DIFF
--- a/devices.go
+++ b/devices.go
@@ -25,9 +25,80 @@ func (u *Unifi) GetDevices(sites []*Site) (*Devices, error) {
 		devices.USGs = append(devices.USGs, loopDevices.USGs...)
 		devices.USWs = append(devices.USWs, loopDevices.USWs...)
 		devices.UDMs = append(devices.UDMs, loopDevices.UDMs...)
+		devices.UXGs = append(devices.UXGs, loopDevices.UXGs...)
 	}
 
 	return devices, nil
+}
+
+// GetUSWs returns all switches, an error, or nil if there are no switches.
+func (u *Unifi) GetUSWs(siteName string) ([]*USW, error) {
+	var response struct {
+		Data []json.RawMessage `json:"data"`
+	}
+
+	err := u.GetData(fmt.Sprintf(APIDevicePath, siteName), &response)
+	if err != nil {
+		return nil, err
+	}
+
+	return u.parseDevices(response.Data, siteName).USWs, nil
+}
+
+// GetUSWs returns all access points, an error, or nil if there are no APs.
+func (u *Unifi) GetUAPs(siteName string) ([]*UAP, error) {
+	var response struct {
+		Data []json.RawMessage `json:"data"`
+	}
+
+	err := u.GetData(fmt.Sprintf(APIDevicePath, siteName), &response)
+	if err != nil {
+		return nil, err
+	}
+
+	return u.parseDevices(response.Data, siteName).UAPs, nil
+}
+
+// GetUSWs returns all dream machines, an error, or nil if there are no UDMs.
+func (u *Unifi) GetUDMs(siteName string) ([]*UDM, error) {
+	var response struct {
+		Data []json.RawMessage `json:"data"`
+	}
+
+	err := u.GetData(fmt.Sprintf(APIDevicePath, siteName), &response)
+	if err != nil {
+		return nil, err
+	}
+
+	return u.parseDevices(response.Data, siteName).UDMs, nil
+}
+
+// GetUSWs returns all 10Gb gateways, an error, or nil if there are no UXGs.
+func (u *Unifi) GetUXGs(siteName string) ([]*UXG, error) {
+	var response struct {
+		Data []json.RawMessage `json:"data"`
+	}
+
+	err := u.GetData(fmt.Sprintf(APIDevicePath, siteName), &response)
+	if err != nil {
+		return nil, err
+	}
+
+	return u.parseDevices(response.Data, siteName).UXGs, nil
+}
+
+// GetUSWs returns all 1Gb gateways, an error, or nil if there are no USGs.
+func (u *Unifi) GetUSGs(siteName string) ([]*USG, error) {
+	var response struct {
+		Data []json.RawMessage `json:"data"`
+	}
+
+	err := u.GetData(fmt.Sprintf(APIDevicePath, siteName), &response)
+	if err != nil {
+		return nil, err
+	}
+
+	return u.parseDevices(response.Data, siteName).USGs, nil
 }
 
 // parseDevices parses the raw JSON from the Unifi Controller into device structures.
@@ -69,6 +140,7 @@ func (u *Unifi) unmarshallUAP(siteName string, payload json.RawMessage, devices 
 	dev := &UAP{SiteName: siteName, SourceName: u.URL}
 	if u.unmarshalDevice("uap", payload, dev) == nil {
 		dev.Name = strings.TrimSpace(pick(dev.Name, dev.Mac))
+		dev.controller = u
 		devices.UAPs = append(devices.UAPs, dev)
 	}
 }
@@ -77,6 +149,7 @@ func (u *Unifi) unmarshallUSG(siteName string, payload json.RawMessage, devices 
 	dev := &USG{SiteName: siteName, SourceName: u.URL}
 	if u.unmarshalDevice("ugw", payload, dev) == nil {
 		dev.Name = strings.TrimSpace(pick(dev.Name, dev.Mac))
+		dev.controller = u
 		devices.USGs = append(devices.USGs, dev)
 	}
 }
@@ -85,6 +158,7 @@ func (u *Unifi) unmarshallUSW(siteName string, payload json.RawMessage, devices 
 	dev := &USW{SiteName: siteName, SourceName: u.URL}
 	if u.unmarshalDevice("usw", payload, dev) == nil {
 		dev.Name = strings.TrimSpace(pick(dev.Name, dev.Mac))
+		dev.controller = u
 		devices.USWs = append(devices.USWs, dev)
 	}
 }
@@ -93,6 +167,7 @@ func (u *Unifi) unmarshallUXG(siteName string, payload json.RawMessage, devices 
 	dev := &UXG{SiteName: siteName, SourceName: u.URL}
 	if u.unmarshalDevice("uxg", payload, dev) == nil {
 		dev.Name = strings.TrimSpace(pick(dev.Name, dev.Mac))
+		dev.controller = u
 		devices.UXGs = append(devices.UXGs, dev)
 	}
 }
@@ -101,6 +176,7 @@ func (u *Unifi) unmarshallUDM(siteName string, payload json.RawMessage, devices 
 	dev := &UDM{SiteName: siteName, SourceName: u.URL}
 	if u.unmarshalDevice("udm", payload, dev) == nil {
 		dev.Name = strings.TrimSpace(pick(dev.Name, dev.Mac))
+		dev.controller = u
 		devices.UDMs = append(devices.UDMs, dev)
 	}
 }

--- a/devices.go
+++ b/devices.go
@@ -140,7 +140,6 @@ func (u *Unifi) unmarshallUAP(site *Site, payload json.RawMessage, devices *Devi
 	dev := &UAP{SiteName: site.Name, SourceName: u.URL}
 	if u.unmarshalDevice("uap", payload, dev) == nil {
 		dev.Name = strings.TrimSpace(pick(dev.Name, dev.Mac))
-		dev.controller = u
 		dev.site = site
 		devices.UAPs = append(devices.UAPs, dev)
 	}
@@ -150,7 +149,6 @@ func (u *Unifi) unmarshallUSG(site *Site, payload json.RawMessage, devices *Devi
 	dev := &USG{SiteName: site.Name, SourceName: u.URL}
 	if u.unmarshalDevice("ugw", payload, dev) == nil {
 		dev.Name = strings.TrimSpace(pick(dev.Name, dev.Mac))
-		dev.controller = u
 		dev.site = site
 		devices.USGs = append(devices.USGs, dev)
 	}
@@ -160,7 +158,6 @@ func (u *Unifi) unmarshallUSW(site *Site, payload json.RawMessage, devices *Devi
 	dev := &USW{SiteName: site.Name, SourceName: u.URL}
 	if u.unmarshalDevice("usw", payload, dev) == nil {
 		dev.Name = strings.TrimSpace(pick(dev.Name, dev.Mac))
-		dev.controller = u
 		dev.site = site
 		devices.USWs = append(devices.USWs, dev)
 	}
@@ -170,7 +167,6 @@ func (u *Unifi) unmarshallUXG(site *Site, payload json.RawMessage, devices *Devi
 	dev := &UXG{SiteName: site.Name, SourceName: u.URL}
 	if u.unmarshalDevice("uxg", payload, dev) == nil {
 		dev.Name = strings.TrimSpace(pick(dev.Name, dev.Mac))
-		dev.controller = u
 		dev.site = site
 		devices.UXGs = append(devices.UXGs, dev)
 	}
@@ -180,7 +176,6 @@ func (u *Unifi) unmarshallUDM(site *Site, payload json.RawMessage, devices *Devi
 	dev := &UDM{SiteName: site.Name, SourceName: u.URL}
 	if u.unmarshalDevice("udm", payload, dev) == nil {
 		dev.Name = strings.TrimSpace(pick(dev.Name, dev.Mac))
-		dev.controller = u
 		dev.site = site
 		devices.UDMs = append(devices.UDMs, dev)
 	}

--- a/devmgr.go
+++ b/devmgr.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 )
 
-// Known commands that can be sent to device manager.
+// Known commands that can be sent to device manager. All of these are implemented.
 //nolint:lll // https://ubntwiki.com/products/software/unifi-controller/api#callable
 const (
 	DevMgrPowerCycle      = "power-cycle"      // mac = switch mac (required), port_idx = PoE port to cycle (required)
@@ -25,11 +25,11 @@ const (
 
 // devMgrCmd is the type marshalled and sent to APIDevMgrPath.
 type devMgrCmd struct {
-	Cmd    string `json:"cmd"`
-	Mac    string `json:"mac"`
-	URL    string `json:"url,omitempty"`
-	Inform string `json:"inform_url,omitempty"`
-	Port   int    `json:"port_idx,omitempty"`
+	Cmd    string `json:"cmd"`                  // Required.
+	Mac    string `json:"mac"`                  // Device MAC (required for most, but not all).
+	URL    string `json:"url,omitempty"`        // External Upgrade only.
+	Inform string `json:"inform_url,omitempty"` // Migration only.
+	Port   int    `json:"port_idx,omitempty"`   // Power Cycle only.
 }
 
 // devMgrCommandReply is for commands with a return value.
@@ -189,7 +189,7 @@ func (u *UXG) Provision() error {
 }
 
 // Upgrade starts a firmware upgrade on a device by MAC address on your site.
-// URL is optional. If provided an external upgrade is performed.
+// URL is optional. If URL is not "" an external upgrade is performed.
 func (s *Site) Upgrade(mac string, url string) error {
 	if url == "" {
 		return s.devMgrCommandSimple(&devMgrCmd{Cmd: DevMgrUpgrade, Mac: mac})
@@ -199,31 +199,31 @@ func (s *Site) Upgrade(mac string, url string) error {
 }
 
 // Upgrade firmware on an access point.
-// URL is optional. If provided an external upgrade is performed.
+// URL is optional. If URL is not "" an external upgrade is performed.
 func (u *UAP) Upgrade(url string) error {
 	return u.site.Upgrade(u.Mac, url)
 }
 
 // Upgrade firmware on a switch.
-// URL is optional. If provided an external upgrade is performed.
+// URL is optional. If URL is not "" an external upgrade is performed.
 func (u *USW) Upgrade(url string) error {
 	return u.site.Upgrade(u.Mac, url)
 }
 
 // Upgrade firmware on a security gateway.
-// URL is optional. If provided an external upgrade is performed.
+// URL is optional. If URL is not "" an external upgrade is performed.
 func (u *USG) Upgrade(url string) error {
 	return u.site.Upgrade(u.Mac, url)
 }
 
 // Upgrade firmware on a dream machine.
-// URL is optional. If provided an external upgrade is performed.
+// URL is optional. If URL is not "" an external upgrade is performed.
 func (u *UDM) Upgrade(url string) error {
 	return u.site.Upgrade(u.Mac, url)
 }
 
 // Upgrade formware on a 10Gb security gateway.
-// URL is optional. If provided an external upgrade is performed.
+// URL is optional. If URL is not "" an external upgrade is performed.
 func (u *UXG) Upgrade(url string) error {
 	return u.site.Upgrade(u.Mac, url)
 }
@@ -249,24 +249,34 @@ func (u *USG) Migrate(url string) error {
 	return u.site.Migrate(u.Mac, url)
 }
 
+// Migrate sends a 10Gb gateway to another controller's URL.
+func (u *UXG) Migrate(url string) error {
+	return u.site.Migrate(u.Mac, url)
+}
+
 // CancelMigrate stops a migration in progress.
 // Probably does not work on devices with built-in controllers like UDM & UXG.
 func (s *Site) CancelMigrate(mac string) error {
 	return s.devMgrCommandSimple(&devMgrCmd{Cmd: DevMgrCancelMigrate, Mac: mac})
 }
 
-// CancelMigrate stops a migration in progress.
+// CancelMigrate stops an access point migration in progress.
 func (u *UAP) CancelMigrate() error {
 	return u.site.CancelMigrate(u.Mac)
 }
 
-// CancelMigrate stops a migration in progress.
+// CancelMigrate stops a switch migration in progress.
 func (u *USW) CancelMigrate() error {
 	return u.site.CancelMigrate(u.Mac)
 }
 
-// CancelMigrate stops a migration in progress.
+// CancelMigrate stops a security gateway migration in progress.
 func (u *USG) CancelMigrate() error {
+	return u.site.CancelMigrate(u.Mac)
+}
+
+// CancelMigrate stops 10Gb gateway a migration in progress.
+func (u *UXG) CancelMigrate() error {
 	return u.site.CancelMigrate(u.Mac)
 }
 

--- a/devmgr.go
+++ b/devmgr.go
@@ -291,7 +291,7 @@ func (s *Site) SpeedTest() error {
 }
 
 // SpeedTestStatus returns the raw response for the status of a speed test.
-// TODO: marshal the response into a data structure. This method will change!
+// XXX: marshal the response into a data structure. This method will change!
 func (s *Site) SpeedTestStatus() ([]byte, error) {
 	body, err := s.devMgrCommandReply(&devMgrCmd{Cmd: DevMgrSpeedTestStatus})
 	// marshal into struct here.

--- a/devmgr.go
+++ b/devmgr.go
@@ -6,21 +6,36 @@ import (
 )
 
 // Known commands that can be sent to device manager.
+//nolint:lll
 const (
-	DevMgrPowerCycle = "power-cycle"
+	DevMgrPowerCycle      = "power-cycle"      // mac = switch mac (required), port_idx = PoE port to cycle (required)
+	DevMgrAdopt           = "adopt"            // mac = device mac (required)
+	DevMgrRestart         = "restart"          // mac = device mac (required)
+	DevMgrForceProvision  = "force-provision"  // mac = device mac (required)
+	DevMgrSpeedTest       = "speedtest"        // Start a speed test
+	DevMgrSpeedTestStatus = "speedtest-status" // Get current state of the speed test
+	DevMgrSetLocate       = "set-locate"       // mac = device mac (required): blink unit to locate
+	DevMgrUnsetLocate     = "unset-locate"     // mac = device mac (required): led to normal state
+	DevMgrUpgrade         = "upgrade"          // mac = device mac (required): upgrade firmware
+	DevMgrUpgradeExternal = "upgrade-external" // mac = device mac (required), url = firmware URL (required)
+	DevMgrMigrate         = "migrate"          // mac = device mac (required), inform_url = New Inform URL for device (required)
+	DevMgrCancelMigrate   = "cancel-migrate"   // mac = device mac (required)
+	DevMgrSpectrumScan    = "spectrum-scan"    // mac = AP mac     (required): trigger RF scan
 )
 
 // command is the type marshalled and sent to APIDevMgrPath.
-type command struct {
+type devMgrCommand struct {
 	Command   string `json:"cmd"`
 	Mac       string `json:"mac"`
-	PortIndex int    `json:"port_idx"`
+	URL       string `json:"url,omitempty"`
+	InformURL string `json:"inform_url,omitempty"`
+	PortIndex int    `json:"port_idx,omitempty"`
 }
 
 // PowerCycle shuts off the PoE and turns it back on for a specific port.
 // Get a USW from the device list to call this.
 func (u *USW) PowerCycle(portIndex int) error {
-	data, err := json.Marshal(&command{
+	data, err := json.Marshal(&devMgrCommand{
 		Command:   DevMgrPowerCycle,
 		Mac:       u.Mac,
 		PortIndex: portIndex,
@@ -29,10 +44,105 @@ func (u *USW) PowerCycle(portIndex int) error {
 		return fmt.Errorf("json marshal: %w", err)
 	}
 
-	_, err = u.controller.GetJSON(APIDevMgrPath, string(data))
+	_, err = u.controller.GetJSON(fmt.Sprintf(APIDevMgrPath, u.SiteName), string(data))
 	if err != nil {
 		return fmt.Errorf("controller: %w", err)
 	}
 
 	return nil
+}
+
+// ScanRF begins a spectrum scan on an access point.
+func (u *UAP) ScanRF() error {
+	data, err := json.Marshal(&devMgrCommand{Command: DevMgrSpectrumScan, Mac: u.Mac})
+	if err != nil {
+		return fmt.Errorf("json marshal: %w", err)
+	}
+
+	_, err = u.controller.GetJSON(fmt.Sprintf(APIDevMgrPath, u.SiteName), string(data))
+	if err != nil {
+		return fmt.Errorf("controller: %w", err)
+	}
+
+	return nil
+}
+
+// Restart a device by MAC address on your site.
+func (s *Site) Restart(mac string) error {
+	data, err := json.Marshal(&devMgrCommand{Command: DevMgrRestart, Mac: mac})
+	if err != nil {
+		return fmt.Errorf("json marshal: %w", err)
+	}
+
+	_, err = s.controller.GetJSON(fmt.Sprintf(APIDevMgrPath, s.Name), string(data))
+	if err != nil {
+		return fmt.Errorf("controller: %w", err)
+	}
+
+	return nil
+}
+
+func (u *UAP) Restart() error {
+	return u.site.Restart(u.Mac)
+}
+
+func (u *USW) Restart() error {
+	return u.site.Restart(u.Mac)
+}
+
+func (u *USG) Restart() error {
+	return u.site.Restart(u.Mac)
+}
+
+func (u *UDM) Restart() error {
+	return u.site.Restart(u.Mac)
+}
+
+func (u *UXG) Restart() error {
+	return u.site.Restart(u.Mac)
+}
+
+// Adopt a device by MAC address to your site.
+func (s *Site) Adopt(mac string) error {
+	data, err := json.Marshal(&devMgrCommand{Command: DevMgrAdopt, Mac: mac})
+	if err != nil {
+		return fmt.Errorf("json marshal: %w", err)
+	}
+
+	_, err = s.controller.GetJSON(fmt.Sprintf(APIDevMgrPath, s.Name), string(data))
+	if err != nil {
+		return fmt.Errorf("controller: %w", err)
+	}
+
+	return nil
+}
+
+// SpeedTest begins a speed test.
+func (s *Site) SpeedTest() error {
+	data, err := json.Marshal(&devMgrCommand{Command: DevMgrSpeedTest})
+	if err != nil {
+		return fmt.Errorf("json marshal: %w", err)
+	}
+
+	_, err = s.controller.GetJSON(fmt.Sprintf(APIDevMgrPath, s.Name), string(data))
+	if err != nil {
+		return fmt.Errorf("controller: %w", err)
+	}
+
+	return nil
+}
+
+// SpeedTestStatus returns the raw response for the status of a speed test.
+func (s *Site) SpeedTestStatus() ([]byte, error) {
+	data, err := json.Marshal(&devMgrCommand{Command: DevMgrSpeedTestStatus})
+	if err != nil {
+		return nil, fmt.Errorf("json marshal: %w", err)
+	}
+
+	b, err := s.controller.GetJSON(fmt.Sprintf(APIDevMgrPath, s.Name), string(data))
+	if err != nil {
+		return nil, fmt.Errorf("controller: %w", err)
+	}
+
+	return b, nil
 }

--- a/devmgr.go
+++ b/devmgr.go
@@ -6,7 +6,7 @@ import (
 )
 
 // Known commands that can be sent to device manager.
-//nolint:lll
+//nolint:lll // https://ubntwiki.com/products/software/unifi-controller/api#callable
 const (
 	DevMgrPowerCycle      = "power-cycle"      // mac = switch mac (required), port_idx = PoE port to cycle (required)
 	DevMgrAdopt           = "adopt"            // mac = device mac (required)
@@ -23,63 +23,54 @@ const (
 	DevMgrSpectrumScan    = "spectrum-scan"    // mac = AP mac     (required): trigger RF scan
 )
 
-// command is the type marshalled and sent to APIDevMgrPath.
-type devMgrCommand struct {
-	Command   string `json:"cmd"`
-	Mac       string `json:"mac"`
-	URL       string `json:"url,omitempty"`
-	InformURL string `json:"inform_url,omitempty"`
-	PortIndex int    `json:"port_idx,omitempty"`
+// devMgrCmd is the type marshalled and sent to APIDevMgrPath.
+type devMgrCmd struct {
+	Cmd    string `json:"cmd"`
+	Mac    string `json:"mac"`
+	URL    string `json:"url,omitempty"`
+	Inform string `json:"inform_url,omitempty"`
+	Port   int    `json:"port_idx,omitempty"`
+}
+
+// devMgrCommandReply is for commands with a return value.
+func (s *Site) devMgrCommandReply(cmd *devMgrCmd) ([]byte, error) {
+	data, err := json.Marshal(cmd)
+	if err != nil {
+		return nil, fmt.Errorf("json marshal: %w", err)
+	}
+
+	b, err := s.controller.GetJSON(fmt.Sprintf(APIDevMgrPath, s.Name), string(data))
+	if err != nil {
+		return nil, fmt.Errorf("controller: %w", err)
+	}
+
+	return b, nil
+}
+
+// devMgrCommandSimple is for commands with no return value.
+func (s *Site) devMgrCommandSimple(cmd *devMgrCmd) error {
+	_, err := s.devMgrCommandReply(cmd)
+	return err
 }
 
 // PowerCycle shuts off the PoE and turns it back on for a specific port.
 // Get a USW from the device list to call this.
 func (u *USW) PowerCycle(portIndex int) error {
-	data, err := json.Marshal(&devMgrCommand{
-		Command:   DevMgrPowerCycle,
-		Mac:       u.Mac,
-		PortIndex: portIndex,
+	return u.site.devMgrCommandSimple(&devMgrCmd{
+		Cmd:  DevMgrPowerCycle,
+		Mac:  u.Mac,
+		Port: portIndex,
 	})
-	if err != nil {
-		return fmt.Errorf("json marshal: %w", err)
-	}
-
-	_, err = u.controller.GetJSON(fmt.Sprintf(APIDevMgrPath, u.SiteName), string(data))
-	if err != nil {
-		return fmt.Errorf("controller: %w", err)
-	}
-
-	return nil
 }
 
 // ScanRF begins a spectrum scan on an access point.
 func (u *UAP) ScanRF() error {
-	data, err := json.Marshal(&devMgrCommand{Command: DevMgrSpectrumScan, Mac: u.Mac})
-	if err != nil {
-		return fmt.Errorf("json marshal: %w", err)
-	}
-
-	_, err = u.controller.GetJSON(fmt.Sprintf(APIDevMgrPath, u.SiteName), string(data))
-	if err != nil {
-		return fmt.Errorf("controller: %w", err)
-	}
-
-	return nil
+	return u.site.devMgrCommandSimple(&devMgrCmd{Cmd: DevMgrSpectrumScan, Mac: u.Mac})
 }
 
 // Restart a device by MAC address on your site.
 func (s *Site) Restart(mac string) error {
-	data, err := json.Marshal(&devMgrCommand{Command: DevMgrRestart, Mac: mac})
-	if err != nil {
-		return fmt.Errorf("json marshal: %w", err)
-	}
-
-	_, err = s.controller.GetJSON(fmt.Sprintf(APIDevMgrPath, s.Name), string(data))
-	if err != nil {
-		return fmt.Errorf("controller: %w", err)
-	}
-
-	return nil
+	return s.devMgrCommandSimple(&devMgrCmd{Cmd: DevMgrRestart, Mac: mac})
 }
 
 // Restart an access point.
@@ -107,48 +98,192 @@ func (u *UXG) Restart() error {
 	return u.site.Restart(u.Mac)
 }
 
-// Adopt a device by MAC address to your site.
-func (s *Site) Adopt(mac string) error {
-	data, err := json.Marshal(&devMgrCommand{Command: DevMgrAdopt, Mac: mac})
-	if err != nil {
-		return fmt.Errorf("json marshal: %w", err)
-	}
-
-	_, err = s.controller.GetJSON(fmt.Sprintf(APIDevMgrPath, s.Name), string(data))
-	if err != nil {
-		return fmt.Errorf("controller: %w", err)
-	}
-
-	return nil
+// Locate a device by MAC address on your site. This makes it blink.
+func (s *Site) Locate(mac string) error {
+	return s.devMgrCommandSimple(&devMgrCmd{Cmd: DevMgrSetLocate, Mac: mac})
 }
 
-// SpeedTest begins a speed test.
+// Locate an access point.
+func (u *UAP) Locate() error {
+	return u.site.Locate(u.Mac)
+}
+
+// Locate a switch.
+func (u *USW) Locate() error {
+	return u.site.Locate(u.Mac)
+}
+
+// Locate a security gateway.
+func (u *USG) Locate() error {
+	return u.site.Locate(u.Mac)
+}
+
+// Locate a dream machine.
+func (u *UDM) Locate() error {
+	return u.site.Locate(u.Mac)
+}
+
+// Locate a 10Gb security gateway.
+func (u *UXG) Locate() error {
+	return u.site.Locate(u.Mac)
+}
+
+// Unlocate a device by MAC address on your site. This makes it stop blinking.
+func (s *Site) Unlocate(mac string) error {
+	return s.devMgrCommandSimple(&devMgrCmd{Cmd: DevMgrUnsetLocate, Mac: mac})
+}
+
+// Unlocate an access point (stop blinking).
+func (u *UAP) Unlocate() error {
+	return u.site.Unlocate(u.Mac)
+}
+
+// Unlocate a switch (stop blinking).
+func (u *USW) Unlocate() error {
+	return u.site.Unlocate(u.Mac)
+}
+
+// Unlocate a security gateway (stop blinking).
+func (u *USG) Unlocate() error {
+	return u.site.Unlocate(u.Mac)
+}
+
+// Unlocate a dream machine (stop blinking).
+func (u *UDM) Unlocate() error {
+	return u.site.Unlocate(u.Mac)
+}
+
+// Unlocate a 10Gb security gateway (stop blinking).
+func (u *UXG) Unlocate() error {
+	return u.site.Unlocate(u.Mac)
+}
+
+// Provision force provisions a device by MAC address on your site.
+func (s *Site) Provision(mac string) error {
+	return s.devMgrCommandSimple(&devMgrCmd{Cmd: DevMgrForceProvision, Mac: mac})
+}
+
+// Provision an access point forcefully.
+func (u *UAP) Provision() error {
+	return u.site.Provision(u.Mac)
+}
+
+// Provision a switch forcefully.
+func (u *USW) Provision() error {
+	return u.site.Provision(u.Mac)
+}
+
+// Provision a security gateway forcefully.
+func (u *USG) Provision() error {
+	return u.site.Provision(u.Mac)
+}
+
+// Provision a dream machine forcefully.
+func (u *UDM) Provision() error {
+	return u.site.Provision(u.Mac)
+}
+
+// Provision a 10Gb security gateway forcefully.
+func (u *UXG) Provision() error {
+	return u.site.Provision(u.Mac)
+}
+
+// Upgrade starts a firmware upgrade on a device by MAC address on your site.
+// URL is optional. If provided an external upgrade is performed.
+func (s *Site) Upgrade(mac string, url string) error {
+	if url == "" {
+		return s.devMgrCommandSimple(&devMgrCmd{Cmd: DevMgrUpgrade, Mac: mac})
+	}
+
+	return s.devMgrCommandSimple(&devMgrCmd{Cmd: DevMgrUpgradeExternal, Mac: mac, URL: url})
+}
+
+// Upgrade firmware on an access point.
+// URL is optional. If provided an external upgrade is performed.
+func (u *UAP) Upgrade(url string) error {
+	return u.site.Upgrade(u.Mac, url)
+}
+
+// Upgrade firmware on a switch.
+// URL is optional. If provided an external upgrade is performed.
+func (u *USW) Upgrade(url string) error {
+	return u.site.Upgrade(u.Mac, url)
+}
+
+// Upgrade firmware on a security gateway.
+// URL is optional. If provided an external upgrade is performed.
+func (u *USG) Upgrade(url string) error {
+	return u.site.Upgrade(u.Mac, url)
+}
+
+// Upgrade firmware on a dream machine.
+// URL is optional. If provided an external upgrade is performed.
+func (u *UDM) Upgrade(url string) error {
+	return u.site.Upgrade(u.Mac, url)
+}
+
+// Upgrade formware on a 10Gb security gateway.
+// URL is optional. If provided an external upgrade is performed.
+func (u *UXG) Upgrade(url string) error {
+	return u.site.Upgrade(u.Mac, url)
+}
+
+// Migrate sends a device to another controller's URL.
+// Probably does not work on devices with built-in controllers like UDM & UXG.
+func (s *Site) Migrate(mac string, url string) error {
+	return s.devMgrCommandSimple(&devMgrCmd{Cmd: DevMgrMigrate, Mac: mac, Inform: url})
+}
+
+// Migrate sends an access point to another controller's URL.
+func (u *UAP) Migrate(url string) error {
+	return u.site.Migrate(u.Mac, url)
+}
+
+// Migrate sends a switch to another controller's URL.
+func (u *USW) Migrate(url string) error {
+	return u.site.Migrate(u.Mac, url)
+}
+
+// Migrate sends a security gateway to another controller's URL.
+func (u *USG) Migrate(url string) error {
+	return u.site.Migrate(u.Mac, url)
+}
+
+// CancelMigrate stops a migration in progress.
+// Probably does not work on devices with built-in controllers like UDM & UXG.
+func (s *Site) CancelMigrate(mac string) error {
+	return s.devMgrCommandSimple(&devMgrCmd{Cmd: DevMgrCancelMigrate, Mac: mac})
+}
+
+// CancelMigrate stops a migration in progress.
+func (u *UAP) CancelMigrate() error {
+	return u.site.CancelMigrate(u.Mac)
+}
+
+// CancelMigrate stops a migration in progress.
+func (u *USW) CancelMigrate() error {
+	return u.site.CancelMigrate(u.Mac)
+}
+
+// CancelMigrate stops a migration in progress.
+func (u *USG) CancelMigrate() error {
+	return u.site.CancelMigrate(u.Mac)
+}
+
+// Adopt a device by MAC address to your site.
+func (s *Site) Adopt(mac string) error {
+	return s.devMgrCommandSimple(&devMgrCmd{Cmd: DevMgrAdopt, Mac: mac})
+}
+
+// SpeedTest begins a speed test on a site.
 func (s *Site) SpeedTest() error {
-	data, err := json.Marshal(&devMgrCommand{Command: DevMgrSpeedTest})
-	if err != nil {
-		return fmt.Errorf("json marshal: %w", err)
-	}
-
-	_, err = s.controller.GetJSON(fmt.Sprintf(APIDevMgrPath, s.Name), string(data))
-	if err != nil {
-		return fmt.Errorf("controller: %w", err)
-	}
-
-	return nil
+	return s.devMgrCommandSimple(&devMgrCmd{Cmd: DevMgrSpeedTest})
 }
 
 // SpeedTestStatus returns the raw response for the status of a speed test.
 // TODO: marshal the response into a data structure. This method will change!
 func (s *Site) SpeedTestStatus() ([]byte, error) {
-	data, err := json.Marshal(&devMgrCommand{Command: DevMgrSpeedTestStatus})
-	if err != nil {
-		return nil, fmt.Errorf("json marshal: %w", err)
-	}
-
-	b, err := s.controller.GetJSON(fmt.Sprintf(APIDevMgrPath, s.Name), string(data))
-	if err != nil {
-		return nil, fmt.Errorf("controller: %w", err)
-	}
-
-	return b, nil
+	body, err := s.devMgrCommandReply(&devMgrCmd{Cmd: DevMgrSpeedTestStatus})
+	// marshal into struct here.
+	return body, err
 }

--- a/devmgr.go
+++ b/devmgr.go
@@ -1,0 +1,38 @@
+package unifi
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Known commands that can be sent to device manager.
+const (
+	DevMgrPowerCycle = "power-cycle"
+)
+
+// command is the type marshalled and sent to APIDevMgrPath.
+type command struct {
+	Command   string `json:"cmd"`
+	Mac       string `json:"mac"`
+	PortIndex int    `json:"port_idx"`
+}
+
+// PowerCycle shuts off the PoE and turns it back on for a specific port.
+// Get a USW from the device list to call this.
+func (u *USW) PowerCycle(portIndex int) error {
+	data, err := json.Marshal(&command{
+		Command:   DevMgrPowerCycle,
+		Mac:       u.Mac,
+		PortIndex: portIndex,
+	})
+	if err != nil {
+		return fmt.Errorf("json marshal: %w", err)
+	}
+
+	_, err = u.controller.GetJSON(APIDevMgrPath, string(data))
+	if err != nil {
+		return fmt.Errorf("controller: %w", err)
+	}
+
+	return nil
+}

--- a/devmgr.go
+++ b/devmgr.go
@@ -82,22 +82,27 @@ func (s *Site) Restart(mac string) error {
 	return nil
 }
 
+// Restart an access point.
 func (u *UAP) Restart() error {
 	return u.site.Restart(u.Mac)
 }
 
+// Restart a switch.
 func (u *USW) Restart() error {
 	return u.site.Restart(u.Mac)
 }
 
+// Restart a security gateway.
 func (u *USG) Restart() error {
 	return u.site.Restart(u.Mac)
 }
 
+// Restart a dream machine.
 func (u *UDM) Restart() error {
 	return u.site.Restart(u.Mac)
 }
 
+// Restart a 10Gb security gateway.
 func (u *UXG) Restart() error {
 	return u.site.Restart(u.Mac)
 }
@@ -133,6 +138,7 @@ func (s *Site) SpeedTest() error {
 }
 
 // SpeedTestStatus returns the raw response for the status of a speed test.
+// TODO: marshal the response into a data structure. This method will change!
 func (s *Site) SpeedTestStatus() ([]byte, error) {
 	data, err := json.Marshal(&devMgrCommand{Command: DevMgrSpeedTestStatus})
 	if err != nil {

--- a/site.go
+++ b/site.go
@@ -20,6 +20,8 @@ func (u *Unifi) GetSites() ([]*Site, error) {
 	sites := []string{} // used for debug log only
 
 	for i, d := range response.Data {
+		// Add the unifi struct to the site.
+		response.Data[i].controller = u
 		// Add special SourceName value.
 		response.Data[i].SourceName = u.URL
 		// If the human name is missing (description), set it to the cryptic name.
@@ -67,6 +69,7 @@ func (u *Unifi) GetSiteDPI(sites []*Site) ([]*DPITable, error) {
 
 // Site represents a site's data.
 type Site struct {
+	controller   *Unifi
 	SourceName   string   `json:"-"`
 	ID           string   `json:"_id"`
 	Name         string   `json:"name"`

--- a/types.go
+++ b/types.go
@@ -42,6 +42,8 @@ const (
 	APIPrefixNew string = "/proxy/network"
 	// APIAnomaliesPath returns site anomalies.
 	APIAnomaliesPath string = "/api/s/%s/stat/anomalies"
+	APICommandPath   string = "/api/s/%s/cmd"
+	APIDevMgrPath    string = APICommandPath + "/devmgr"
 )
 
 // path returns the correct api path based on the new variable.

--- a/uap.go
+++ b/uap.go
@@ -9,7 +9,6 @@ import (
 // This was auto generated then edited by hand to get all the data types right.
 type UAP struct {
 	site         *Site
-	controller   *Unifi
 	SourceName   string   `json:"-"`
 	ID           string   `json:"_id"`
 	Adopted      FlexBool `json:"adopted"`

--- a/uap.go
+++ b/uap.go
@@ -8,6 +8,7 @@ import (
 // UAP represents all the data from the Ubiquiti Controller for a Unifi Access Point.
 // This was auto generated then edited by hand to get all the data types right.
 type UAP struct {
+	site         *Site
 	controller   *Unifi
 	SourceName   string   `json:"-"`
 	ID           string   `json:"_id"`

--- a/uap.go
+++ b/uap.go
@@ -8,6 +8,7 @@ import (
 // UAP represents all the data from the Ubiquiti Controller for a Unifi Access Point.
 // This was auto generated then edited by hand to get all the data types right.
 type UAP struct {
+	controller   *Unifi
 	SourceName   string   `json:"-"`
 	ID           string   `json:"_id"`
 	Adopted      FlexBool `json:"adopted"`

--- a/udm.go
+++ b/udm.go
@@ -3,6 +3,7 @@ package unifi
 // UDM represents all the data from the Ubiquiti Controller for a Unifi Dream Machine.
 // The UDM shares several structs/type-data with USW and USG.
 type UDM struct {
+	controller             *Unifi
 	SourceName             string               `json:"-"`
 	SiteID                 string               `json:"site_id"`
 	SiteName               string               `json:"-"`

--- a/udm.go
+++ b/udm.go
@@ -4,7 +4,6 @@ package unifi
 // The UDM shares several structs/type-data with USW and USG.
 type UDM struct {
 	site                   *Site
-	controller             *Unifi
 	SourceName             string               `json:"-"`
 	SiteID                 string               `json:"site_id"`
 	SiteName               string               `json:"-"`

--- a/udm.go
+++ b/udm.go
@@ -3,6 +3,7 @@ package unifi
 // UDM represents all the data from the Ubiquiti Controller for a Unifi Dream Machine.
 // The UDM shares several structs/type-data with USW and USG.
 type UDM struct {
+	site                   *Site
 	controller             *Unifi
 	SourceName             string               `json:"-"`
 	SiteID                 string               `json:"site_id"`

--- a/usg.go
+++ b/usg.go
@@ -7,6 +7,7 @@ import (
 
 // USG represents all the data from the Ubiquiti Controller for a Unifi Security Gateway.
 type USG struct {
+	site                  *Site
 	controller            *Unifi
 	SourceName            string               `json:"-"`
 	ID                    string               `json:"_id"`

--- a/usg.go
+++ b/usg.go
@@ -7,6 +7,7 @@ import (
 
 // USG represents all the data from the Ubiquiti Controller for a Unifi Security Gateway.
 type USG struct {
+	controller            *Unifi
 	SourceName            string               `json:"-"`
 	ID                    string               `json:"_id"`
 	Adopted               FlexBool             `json:"adopted"`

--- a/usg.go
+++ b/usg.go
@@ -8,7 +8,6 @@ import (
 // USG represents all the data from the Ubiquiti Controller for a Unifi Security Gateway.
 type USG struct {
 	site                  *Site
-	controller            *Unifi
 	SourceName            string               `json:"-"`
 	ID                    string               `json:"_id"`
 	Adopted               FlexBool             `json:"adopted"`

--- a/usw.go
+++ b/usw.go
@@ -7,6 +7,7 @@ import (
 
 // USW represents all the data from the Ubiquiti Controller for a Unifi Switch.
 type USW struct {
+	controller           *Unifi
 	SourceName           string           `json:"-"`
 	SiteName             string           `json:"-"`
 	ID                   string           `json:"_id"`

--- a/usw.go
+++ b/usw.go
@@ -8,7 +8,6 @@ import (
 // USW represents all the data from the Ubiquiti Controller for a Unifi Switch.
 type USW struct {
 	site                 *Site
-	controller           *Unifi
 	SourceName           string           `json:"-"`
 	SiteName             string           `json:"-"`
 	ID                   string           `json:"_id"`

--- a/usw.go
+++ b/usw.go
@@ -7,6 +7,7 @@ import (
 
 // USW represents all the data from the Ubiquiti Controller for a Unifi Switch.
 type USW struct {
+	site                 *Site
 	controller           *Unifi
 	SourceName           string           `json:"-"`
 	SiteName             string           `json:"-"`

--- a/uxg.go
+++ b/uxg.go
@@ -3,6 +3,7 @@ package unifi
 // UXG represents all the data from the Ubiquiti Controller for a UniFi 10Gb Gateway.
 // The UDM shares several structs/type-data with USW and USG.
 type UXG struct {
+	site                       *Site
 	controller                 *Unifi
 	SourceName                 string                  `json:"-"`
 	SiteName                   string                  `json:"-"`

--- a/uxg.go
+++ b/uxg.go
@@ -4,7 +4,6 @@ package unifi
 // The UDM shares several structs/type-data with USW and USG.
 type UXG struct {
 	site                       *Site
-	controller                 *Unifi
 	SourceName                 string                  `json:"-"`
 	SiteName                   string                  `json:"-"`
 	ID                         string                  `json:"_id"`

--- a/uxg.go
+++ b/uxg.go
@@ -3,6 +3,7 @@ package unifi
 // UXG represents all the data from the Ubiquiti Controller for a UniFi 10Gb Gateway.
 // The UDM shares several structs/type-data with USW and USG.
 type UXG struct {
+	controller                 *Unifi
 	SourceName                 string                  `json:"-"`
 	SiteName                   string                  `json:"-"`
 	ID                         string                  `json:"_id"`


### PR DESCRIPTION
Adds a port power cycle method to USW struct. Closes #43.

Quick use:
```go
u, _ := unifi.NewUnifi(config)
switches, _ := u.GetUSWs("default") // default site.

// Power cycle port 3 on the first switch (or only switch).
// You should do error checking above, and you should 
// probably loop `switches` to check the name or MAC
// and make sure you have the right one.
// `switches` may be nil when err is nil.
err := switches[0].PowerCycle(3)
```

I went ahead and added all the other `devmgr` methods too.  y knot