### PR TITLE
Add ability to validate controller SSL cert against provided PEM.

### DIFF
--- a/types.go
+++ b/types.go
@@ -108,6 +108,7 @@ type Unifi struct {
 
 type fingerprints []string
 
+// Contains returns true if the fingerprint is in the list.
 func (f fingerprints) Contains(s string) bool {
 	for i := range f {
 		if s == f[i] {


### PR DESCRIPTION
This change allows passing a list of certificates to validate the controller against. If the cert the controller provides is in the list, then it's valid, otherwise it's not. Needs more testing. Used [this](https://gist.github.com/OrangeCat9/8c82eb40b6cc1d25917219a07be3b6b6) as a guide, and I'm sure I'll find a better way as I test this out.

For https://github.com/unifi-poller/unifi-poller/issues/266