### PR TITLE
Add methods to get Rogue APs.

### DIFF
--- a/types.go
+++ b/types.go
@@ -14,6 +14,8 @@ var ErrCannotUnmarshalFlexInt = fmt.Errorf("cannot unmarshal to FlexInt")
 // This is a list of unifi API paths.
 // The %s in each string must be replaced with a Site.Name.
 const (
+	// APIRogueAP shows your neighbors' wifis.
+	APIRogueAP string = "/api/s/%s/stat/rogueap"
 	// APIStatusPath shows Controller version.
 	APIStatusPath string = "/status"
 	// APIEventPath contains UniFi Event data.


### PR DESCRIPTION
This simply adds 1 new type and 2 new methods to get RogueAPs from your sites.

for https://github.com/unifi-poller/unifi-poller/issues/268